### PR TITLE
fix the "can't convert pgf.preamble to stri" bug when i import sciai

### DIFF
--- a/SciAI/sciai/utils/plot_utils.py
+++ b/SciAI/sciai/utils/plot_utils.py
@@ -81,10 +81,7 @@ _pgf_with_latex = {
     "ytick.labelsize": 8,
     "font.size": 10,
     "figure.figsize": _figsize(1.0),
-    "pgf.preamble": [
-        r"\usepackage[utf8x]{inputenc}",
-        r"\usepackage[T1]{fontenc}",
-    ]
+    "pgf.preamble": r"\usepackage[utf8x]{inputenc} \usepackage[T1]{fontenc}",
 }
 mpl.rcParams.update(_pgf_with_latex)
 


### PR DESCRIPTION
Signed-off-by: Zdmai <jhzhou.ai@gmail.com>

I build sciai from src, but there is a bug when I import sciai

bug is "ValueError: Key pgf.preamble: Could not convert ['\\usepackage[utf8x]{inputenc}', '\\usepackage[T1]{fontenc}'] to str" in the sciai/utils/plot_utils.py file

MacOS's container
OS: Debian GNU/Linux 12 (bookworm) aarch64 
Kernel: 6.6.26-linuxkit 
aarch64
python 3.8.19

